### PR TITLE
Secret injection via Docker secrets (#28)

### DIFF
--- a/agent/bin/agent-entrypoint.sh
+++ b/agent/bin/agent-entrypoint.sh
@@ -34,6 +34,10 @@ cat > /root/.claude/settings.json <<'EOF'
 }
 EOF
 
+# ── Inject API keys from Docker secrets (if present) ────────────────────────
+[ -f /run/secrets/anthropic_key ] && export ANTHROPIC_API_KEY=$(cat /run/secrets/anthropic_key)
+[ -f /run/secrets/github_token ]  && export GITHUB_TOKEN=$(cat /run/secrets/github_token)
+
 # ── Role-specific config from filesystem ────────────────────────────────────
 # .context/agents/{role}/config.json → model override
 # .context/agents/{role}/prompt.md   → role prompt (preferred over AGENT_PROMPT)

--- a/manager/templates/team-compose.yml.ejs
+++ b/manager/templates/team-compose.yml.ejs
@@ -10,6 +10,15 @@ networks:
 volumes:
   git-<%- team.name %>:
 
+<% const secretNames = Object.keys(secrets || {}) -%>
+<% if (secretNames.length > 0) { -%>
+secrets:
+<% secretNames.forEach(function(name) { -%>
+  <%- name %>:
+    file: <%- secrets[name] %>
+<% }); -%>
+
+<% } -%>
 services:
 
   # ── IRC server ─────────────────────────────────────────────────────────────
@@ -62,6 +71,12 @@ services:
 <% Object.entries(agent.env || {}).forEach(function([k, v]) { -%>
       <%- k %>: <%- JSON.stringify(String(v)) %>
 <% }); -%>
+<% if (secretNames.length > 0) { -%>
+    secrets:
+<% secretNames.forEach(function(name) { -%>
+      - <%- name %>
+<% }); -%>
+<% } -%>
     depends_on:
       ergo-<%- team.name %>:
         condition: service_started


### PR DESCRIPTION
## Summary

- Adds `--secrets <dir>` flag to `create-team` CLI command
- Manager resolves which secret files exist at team-creation time and writes their absolute paths into the generated `docker-compose.yml` under the top-level `secrets:` block
- Agent entrypoint reads `/run/secrets/anthropic_key` and `/run/secrets/github_token` at container startup and exports as `ANTHROPIC_API_KEY` / `GITHUB_TOKEN`
- Secret keys are never passed as plain env vars; not visible in `docker inspect` or process listings
- Fully optional — existing `create-team` calls without `--secrets` work unchanged

## Changes

| File | Change |
|------|--------|
| `agent/bin/agent-entrypoint.sh` | Step 3b: inject secrets from `/run/secrets/` into env |
| `manager/src/orchestrator/compose.js` | `resolveSecrets()`, updated `renderCompose`/`startTeam` signatures |
| `manager/src/index.js` | `--secrets` arg parsing, `secretsDir` forwarded to `startTeam` |
| `manager/templates/team-compose.yml.ejs` | Conditional top-level `secrets:` block + per-agent `secrets:` list |

## Test plan

- [ ] `create-team --config team.json --secrets ./secrets/` with both files present → compose file has `secrets:` block with correct `file:` paths and each agent lists both secrets
- [ ] Same command with only `anthropic_key.txt` present → only `anthropic_key` appears in compose
- [ ] `create-team --config team.json` (no `--secrets`) → compose file has no `secrets:` block, agents have no `secrets:` list
- [ ] Inside running agent container: `echo $ANTHROPIC_API_KEY` shows key value; `docker inspect <container>` does NOT show it in Env
- [ ] `docker inspect <container>` → no secret values in Env or Cmd fields

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)