### PR TITLE
Add WebSocket stream for real-time monitoring

### DIFF
--- a/manager/src/api/index.js
+++ b/manager/src/api/index.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import { getTeam, updateTeam } from '../store/teams.js'
+import { broadcastHeartbeat } from './ws.js'
 import teamsRouter from './teams.js'
 import agentsRouter from './agents.js'
 import channelsRouter from './channels.js'
@@ -20,6 +21,7 @@ export function createApp() {
       a.id === agentId ? { ...a, last_heartbeat: now } : a
     )
     updateTeam(teamId, { agents })
+    broadcastHeartbeat(teamId, agentId, now)
     console.log(`[heartbeat] team=${teamId} agent=${agentId} at=${now}`)
     return res.json({ ok: true, at: now })
   })

--- a/manager/src/api/ws.js
+++ b/manager/src/api/ws.js
@@ -1,0 +1,145 @@
+import { WebSocketServer } from 'ws'
+import { getTeam } from '../store/teams.js'
+import { registerBroadcaster } from '../irc/router.js'
+
+// WebSocket.OPEN numeric value (avoids importing the class just for the constant)
+const WS_OPEN = 1
+
+// Per-team subscriber sets  —  Map<teamId, Set<WebSocket>>
+const subscriptions = new Map()
+
+let _unregisterBroadcaster = null
+
+/**
+ * Send a JSON payload to all clients subscribed to a team.
+ * Messages are dropped (not buffered) when the socket is busy — backpressure.
+ */
+function fanOut(teamId, payload) {
+  const clients = subscriptions.get(teamId)
+  if (!clients) return
+  for (const ws of clients) {
+    if (ws.readyState === WS_OPEN && ws.bufferedAmount === 0) {
+      ws.send(payload)
+    }
+  }
+}
+
+/**
+ * Broadcast a heartbeat event to clients subscribed to a team.
+ * Safe to call before attachWebSocketServer — fanOut is a no-op until
+ * subscriptions are populated.
+ */
+export function broadcastHeartbeat(teamId, agentId, timestamp) {
+  fanOut(teamId, JSON.stringify({ type: 'heartbeat', teamId, agentId, timestamp }))
+}
+
+/**
+ * Broadcast an agent lifecycle status change to clients subscribed to a team.
+ * status: 'spawned' | 'killed' | 'stalled'
+ */
+export function broadcastAgentStatus(teamId, agentId, status) {
+  fanOut(teamId, JSON.stringify({ type: 'agent_status', teamId, agentId, status }))
+}
+
+/**
+ * Attach a WebSocket server to an existing HTTP server (call once, after listen).
+ *
+ * Only upgrades on path `/ws` are accepted; all others get a 400 close.
+ *
+ * Client → server protocol:
+ *   { type: 'subscribe', teamId: string }   — subscribe (or re-subscribe) to a team
+ *
+ * Server → client protocol:
+ *   { type: 'subscribed', teamId }           — subscription confirmed
+ *   { type: 'message',    teamId, channel, nick, text, time, tag, tagBody }
+ *   { type: 'heartbeat',  teamId, agentId, timestamp }
+ *   { type: 'agent_status', teamId, agentId, status }
+ *   { type: 'error',      code, message }
+ *
+ * Auth: the client must send a valid teamId that exists in the team store.
+ * This mirrors the REST API's tenant scoping (no team → 404 style rejection).
+ * Idempotent — calling again after the first attach is a no-op.
+ */
+export function attachWebSocketServer(server) {
+  if (_unregisterBroadcaster) return // already attached
+
+  const wss = new WebSocketServer({ noServer: true })
+
+  // Hook into IrcRouter — fan out every incoming IRC message to subscribed clients
+  _unregisterBroadcaster = registerBroadcaster((entry) => {
+    fanOut(entry.teamId, JSON.stringify({ type: 'message', ...entry }))
+  })
+
+  wss.on('connection', (ws) => {
+    let currentTeamId = null
+
+    ws.on('message', (raw) => {
+      let msg
+      try {
+        msg = JSON.parse(raw)
+      } catch {
+        ws.send(JSON.stringify({ type: 'error', code: 'INVALID_JSON', message: 'message must be JSON' }))
+        return
+      }
+
+      if (msg.type !== 'subscribe') {
+        ws.send(JSON.stringify({ type: 'error', code: 'UNKNOWN_TYPE', message: `unknown type: ${msg.type}` }))
+        return
+      }
+
+      const newTeamId = msg.teamId
+      if (!newTeamId || typeof newTeamId !== 'string') {
+        ws.send(JSON.stringify({ type: 'error', code: 'MISSING_TEAM_ID', message: 'teamId required' }))
+        return
+      }
+
+      const team = getTeam(newTeamId)
+      if (!team) {
+        ws.send(JSON.stringify({ type: 'error', code: 'NOT_FOUND', message: 'team not found' }))
+        return
+      }
+
+      // Unsubscribe from previous team when switching
+      if (currentTeamId) {
+        subscriptions.get(currentTeamId)?.delete(ws)
+      }
+
+      currentTeamId = newTeamId
+      if (!subscriptions.has(currentTeamId)) subscriptions.set(currentTeamId, new Set())
+      subscriptions.get(currentTeamId).add(ws)
+
+      ws.send(JSON.stringify({ type: 'subscribed', teamId: currentTeamId }))
+    })
+
+    ws.on('close', () => {
+      if (currentTeamId) {
+        subscriptions.get(currentTeamId)?.delete(ws)
+      }
+    })
+
+    ws.on('error', (err) => {
+      console.error('[ws] client error:', err.message)
+    })
+  })
+
+  // Only accept upgrades on /ws — destroy anything else
+  server.on('upgrade', (req, socket, head) => {
+    let pathname
+    try {
+      pathname = new URL(req.url, 'http://localhost').pathname
+    } catch {
+      socket.destroy()
+      return
+    }
+
+    if (pathname !== '/ws') {
+      socket.write('HTTP/1.1 400 Bad Request\r\n\r\n')
+      socket.destroy()
+      return
+    }
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req)
+    })
+  })
+}

--- a/manager/src/index.js
+++ b/manager/src/index.js
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 import * as teamStore from './store/teams.js'
 import { startTeam, stopTeam } from './orchestrator/compose.js'
 import { createApp } from './api/index.js'
+import { attachWebSocketServer } from './api/ws.js'
 
 const [, , command, ...rest] = process.argv
 
@@ -71,9 +72,10 @@ async function main() {
     case 'serve': {
       const { port = '8080' } = parseArgs(rest)
       const app = createApp()
-      app.listen(Number(port), () => {
-        console.log(`[manager] REST API listening on :${port}`)
+      const server = app.listen(Number(port), () => {
+        console.log(`[manager] REST API + WebSocket listening on :${port}`)
       })
+      attachWebSocketServer(server)
       break
     }
 


### PR DESCRIPTION
## Summary

- New `manager/src/api/ws.js`: WebSocket server co-hosted on the Express HTTP port via `upgrade` handler on `/ws` path
- Per-team subscription scoping (`Map<teamId, Set<WebSocket>>`)
- Fan-out for three event types: `message` (IRC), `heartbeat`, `agent_status`
- Backpressure: drops messages when socket is not OPEN or `bufferedAmount > 0`
- Auth: team existence check (mirrors REST API's 404-style tenant scoping)
- Wired into `serve` command in `manager/src/index.js`
- `broadcastHeartbeat` called from existing `/heartbeat/:teamId/:agentId` endpoint

## Test plan

- [ ] Start manager with `serve` command, confirm log shows `REST API + WebSocket listening`
- [ ] Connect WS client to `ws://localhost:8080/ws`, send `{ type: "subscribe", teamId: "<id>" }`, verify `{ type: "subscribed" }` response
- [ ] Send heartbeat POST, verify WS client receives `{ type: "heartbeat" }` event
- [ ] Verify unknown paths (non-`/ws`) return 400 on upgrade
- [ ] Verify invalid JSON / unknown message type returns `{ type: "error" }` response
- [ ] Verify subscribing to unknown teamId returns `{ type: "error", code: "NOT_FOUND" }`

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)