### PR TITLE
Fix double reconnect timer race in IrcGateway

### DIFF
--- a/manager/src/irc/gateway.js
+++ b/manager/src/irc/gateway.js
@@ -77,6 +77,7 @@ export class IrcGateway extends EventEmitter {
   }
 
   #scheduleReconnect() {
+    clearTimeout(this.#reconnectTimer)
     this.#reconnectTimer = setTimeout(() => {
       this.connect()
     }, this.#reconnectDelay)


### PR DESCRIPTION
## Summary
- Clear existing reconnect timer before scheduling a new one in `#scheduleReconnect()`, preventing orphaned timers when both `socket close` and `close` events fire on a single disconnect
- One-line fix: `clearTimeout(this.#reconnectTimer)` at the top of the method

## Root Cause
Both `socket close` and `close` events from irc-framework can fire in rapid succession on a single disconnect. Each calls `#scheduleReconnect()`, which overwrites `this.#reconnectTimer` without clearing the previous value — orphaning Timer A while Timer B takes its place. Both eventually fire `connect()`, creating duplicate IRC connections per team.

## Test plan
- [ ] Verify `clearTimeout` is idempotent (safe to call on null — it is per spec)
- [ ] Verify reconnect still works normally after a single disconnect event
- [ ] Verify rapid double-event scenario no longer creates two connections

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)