### PR TITLE
Fix Docker build and Ergo config bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: build build-agent build-agent-claude build-manager build-ergo
+.PHONY: build build-agent build-agent-claude build-manager build-ergo build-git-init
 
 ## Build all images in dependency order
-build: build-agent build-agent-claude build-manager build-ergo
+build: build-agent build-agent-claude build-manager build-ergo build-git-init
 
 ## a1-agent-base: base image for all agent containers
 build-agent:
@@ -18,3 +18,7 @@ build-manager:
 ## a1-ergo: IRC server with bundled config
 build-ergo:
 	docker build -t a1-ergo:latest templates/ergo/
+
+## a1-git-init: one-shot git volume initialiser
+build-git-init:
+	docker build -t a1-git-init:latest git-init/

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,5 +1,13 @@
 FROM node:22-slim
-RUN apt-get update && apt-get install -y docker-compose-plugin curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --production

--- a/manager/templates/team-compose.yml.ejs
+++ b/manager/templates/team-compose.yml.ejs
@@ -27,7 +27,7 @@ services:
     volumes:
       - type: bind
         source: <%- ergo.configPath %>
-        target: /ircd/config/ircd.yaml
+        target: /ircd/ircd.yaml
         read_only: true
     restart: unless-stopped
 

--- a/templates/ergo/ircd.yaml
+++ b/templates/ergo/ircd.yaml
@@ -5,7 +5,7 @@ network:
     name: a1-engineer
 
 server:
-    name: a1-irc
+    name: a1-irc.local
 
     listeners:
         # Listen on all interfaces, plain IRC port — internal Docker network only
@@ -16,8 +16,8 @@ server:
     lookup-hostnames: false
     check-ident: false
 
-    # Maximum concurrent client connections
-    max-sendq: 1048576
+    # Maximum send queue size per client
+    max-sendq: 1M
 
     # Relaymsg enabled for potential metadata use
     relaymsg:
@@ -62,16 +62,19 @@ history:
         query-cutoff: 'none'
 
 limits:
-    # Max connected clients across all agent containers
-    clients: 50
-    channels:
-        max: 20
-    registration-messages: 1024
-    nick-length: 32
-    identifier-length: 32
+    nicklen: 32
+    identlen: 20
+    realnamelen: 150
+    channellen: 64
+    awaylen: 390
+    kicklen: 390
+    topiclen: 390
+    monitor-entries: 100
+    whowas-entries: 100
+    chan-list-modes: 100
 
 datastore:
-    path: /ircd/data/ircd.db
+    path: /ircd/ircd.db
 
 logging:
     -


### PR DESCRIPTION
## Summary
- Fix 4 Ergo IRC server config bugs that prevented startup (server name, max-sendq format, limits field names, datastore path)
- Fix compose template mount path mismatch (`/ircd/config/ircd.yaml` → `/ircd/ircd.yaml`)
- Fix manager Dockerfile: add Docker official apt repo so `docker-compose-plugin` installs correctly on node:22-slim
- Add missing `build-git-init` target to Makefile

All bugs found during manual testing of team stack spin-up. After fixes, all 5 Docker images build successfully and ergo + git-init containers run correctly.

## Bugs found & fixed

| Bug | File | Fix |
|-----|------|-----|
| Server name not FQDN | `templates/ergo/ircd.yaml` | `a1-irc` → `a1-irc.local` |
| max-sendq needs unit | `templates/ergo/ircd.yaml` | `1048576` → `1M` |
| Wrong limit field names | `templates/ergo/ircd.yaml` | `nick-length` → `nicklen`, etc. |
| Datastore dir missing | `templates/ergo/ircd.yaml` | `/ircd/data/ircd.db` → `/ircd/ircd.db` |
| Mount path mismatch | `team-compose.yml.ejs` | `/ircd/config/ircd.yaml` → `/ircd/ircd.yaml` |
| docker-compose-plugin not in default repos | `manager/Dockerfile` | Add Docker apt repo |
| Missing Makefile target | `Makefile` | Add `build-git-init` |

## Test plan
- [x] All 5 Docker images build (`make build`)
- [x] Ergo starts and accepts IRC connections
- [x] git-init clones repo and creates worktrees
- [ ] Full stack test with agent containers

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)