### PR TITLE
Add ergo.hostPort for direct IRC client access (Halloy)

### DIFF
--- a/configs/hamburg.json
+++ b/configs/hamburg.json
@@ -17,6 +17,7 @@
   "ergo": {
     "image": "a1-ergo:latest",
     "configPath": "./templates/ergo/ircd.yaml",
-    "port": 6667
+    "port": 6667,
+    "hostPort": 6667
   }
 }

--- a/configs/team-config.schema.json
+++ b/configs/team-config.schema.json
@@ -88,6 +88,12 @@
           "type": "integer",
           "description": "IRC port exposed on the internal Docker network.",
           "default": 6667
+        },
+        "hostPort": {
+          "type": "integer",
+          "description": "Host port to expose for direct IRC client access (e.g., Halloy). If set, Ergo is reachable at localhost:<hostPort>. Omit to keep IRC internal-only.",
+          "minimum": 1024,
+          "maximum": 65535
         }
       }
     }

--- a/manager/src/orchestrator/compose.test.js
+++ b/manager/src/orchestrator/compose.test.js
@@ -140,6 +140,21 @@ describe('renderCompose — api-key auth', () => {
   })
 })
 
+describe('renderCompose — ergo hostPort', () => {
+  it('exposes host port when ergo.hostPort is set', async () => {
+    const yaml = await renderCompose({
+      ...BASE_CONFIG,
+      ergo: { ...BASE_CONFIG.ergo, hostPort: 16667 },
+    })
+    expect(yaml).toContain('"16667:6667"')
+  })
+
+  it('does not expose ports when hostPort is omitted', async () => {
+    const yaml = await renderCompose({ ...BASE_CONFIG })
+    expect(yaml).not.toContain('ports:')
+  })
+})
+
 describe('renderCompose — invalid auth', () => {
   it('throws for unknown auth mode', async () => {
     await expect(

--- a/manager/templates/team-compose.yml.ejs
+++ b/manager/templates/team-compose.yml.ejs
@@ -24,6 +24,10 @@ services:
     image: <%- ergo.image %>
     networks:
       - net-<%- team.name %>
+<% if (ergo.hostPort) { -%>
+    ports:
+      - "<%- ergo.hostPort %>:<%- ergo.port || 6667 %>"
+<% } -%>
     volumes:
       - type: bind
         source: <%- ergo.configPath %>


### PR DESCRIPTION
## Summary
- Adds optional `ergo.hostPort` to team config — when set, exposes the Ergo IRC server on the host so external IRC clients (Halloy, irssi, etc.) can connect directly
- Updates compose template to add `ports:` mapping when hostPort is configured
- Updates hamburg.json to expose port 6667 by default
- Adds 2 new tests for hostPort rendering (with and without)

## Usage

In your team config:
```json
"ergo": {
  "hostPort": 6667
}
```

Then connect Halloy to `localhost:6667` — you'll see all agent IRC traffic in real time.

For multiple teams, use different host ports (6667, 6668, etc.).

## Test plan
- [x] 36/36 tests pass (2 new for hostPort)
- [x] Compose renders `ports: "6667:6667"` when hostPort is set
- [x] Compose omits ports block when hostPort is omitted
- [ ] Manual: connect Halloy to exposed port and verify live agent chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)